### PR TITLE
Fix examples

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,14 +1,8 @@
 - name: Getting started
   category: getting-started
   children:
-    - name: Create your account
+    - name: Introduction
       path: /getting-started
-    - name: Open your snippet
-      path: /getting-started#open-your-first-snippet
-    - name: Install your SDK
-      path: /getting-started#install-your-first-sdk
-    - name: Render your snippet
-      path: /getting-started#render-your-first-snippet
 - name: Learning more
   category: components
   children:

--- a/_includes/code.html
+++ b/_includes/code.html
@@ -30,9 +30,10 @@
           <div class="col-4">
             <select class="form-control form-control-sm custom-select" data-toggle-type="value" data-toggle-language="true">
               <option value="bash">cURL</option>
-              <!-- <option value="node">Node.js</option> -->
+              <option value="javascript">Node</option>
               <option value="php">PHP</option>
               <option value="ruby">Ruby</option>
+              <option value="html">Web</option>
             </select>
           </div>
         {% endunless %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,8 +49,7 @@
             {% if page.category == section.category %}
               <nav class="nav nav-pills flex-column">
                 {% for item in section.children %}
-                  {% assign item_url = item.path %}
-                  <a class="nav-link{% if page.url == item_url %} active{% endif %}" href="{{ item.path }}">{{ item.name }}</a>
+                  <a class="nav-link{% if page.url == item.path %} active{% endif %}" href="{{ item.path }}">{{ item.name }}</a>
                 {% endfor %}
               </nav>
             {% endif %}

--- a/api.html
+++ b/api.html
@@ -45,19 +45,27 @@ javascripts :
         <div class="card-body">
           <nav class="nav nav-pills nav-fill">
             <a class="nav-item nav-link active" data-toggle-type="activity" data-toggle-language="bash">cURL</a>
+            <a class="nav-item nav-link" data-toggle-type="activity" data-toggle-language="javascript">Node</a>
             <a class="nav-item nav-link" data-toggle-type="activity" data-toggle-language="php">PHP</a>
             <a class="nav-item nav-link" data-toggle-type="activity" data-toggle-language="ruby">Ruby</a>
+            <a class="nav-item nav-link" data-toggle-type="activity" data-toggle-language="html">Web</a>
           </nav>
         </div>
         <div class="card-footer text-muted">
           <p class="m-0" data-toggle-type="visibility" data-toggle-language="bash">
             <small>By default, the Jahuty API Docs demonstrate using <code>curl</code> to interact with the API over HTTPS. Select one of our official SDKs to see examples in code.</small>
           </p>
+          <p class="m-0" data-toggle-type="visibility" data-toggle-language="javascript">
+            <small><code>$ npm install jahuty --save</code></small> <a href="https://github.com/jahuty/jahuty-node" target="_blank"><i class="fab fa-github ml-2"></i></a>
+          </p>
           <p class="m-0" data-toggle-type="visibility" data-toggle-language="php">
             <small><code>$ composer require jahuty/jahuty-php</code></small> <a href="https://github.com/jahuty/jahuty-php" target="_blank"><i class="fab fa-github ml-2"></i></a>
           </p>
           <p class="m-0" data-toggle-type="visibility" data-toggle-language="ruby">
             <small><code>$ gem install jahuty</code></small> <a href="https://github.com/jahuty/jahuty-ruby" target="_blank"><i class="fab fa-github ml-2"></i></a>
+          </p>
+          <p class="m-0" data-toggle-type="visibility" data-toggle-language="html">
+            <small><code>&lt;script src="https://unpkg.com/@jahuty/jahuty"&gt;&lt;/script&gt;</code></small> <a href="https://github.com/jahuty/jahuty-node" target="_blank"><i class="fab fa-github ml-2"></i></a>
           </p>
         </div>
       </div>
@@ -95,10 +103,8 @@ javascripts :
     </div>
     <div class="col-md-6">
 {% capture code %}
-curl \
-  https://api.jahuty.com/snippets/1/render \
-  -H "Authorization: Bearer {{ key }}"; \
-  echo
+curl https://api.jahuty.com/snippets/1/render \
+  -H "Authorization: Bearer {{ key }}"; echo
 {% endcapture %}
       {% include code.html header="Authenticated request" language="bash" code=code toggle=false select=false %}
       <div class="card my-3">
@@ -258,16 +264,12 @@ curl \
     </div>
     <div class="col-md-6">
 {% capture php %}
-use Jahuty\Jahuty\Jahuty;
-use Jahuty\Jahuty\Snippet;
-use Jahuty\Jahuty\Exception\NotOk;
-
-Jahuty::setKey('{{ key }}');
+$jahuty = new \Jahuty\Client('{{ key }}');
 
 try {
   // Returns 404 (raising exception) because snippet and key do not match.
-  Snippet::get(999);
-} catch (NotOk $e) {
+  echo $jahuty->snippets->render(999);
+} catch (\Jahuty\Exception\Error $e) {
   $p = $e->getProblem();
 
   echo $p->getStatus();
@@ -290,6 +292,7 @@ rescue Jahuty::Exception::NotOk => e
   puts p.status
   puts p.type
   puts p.detail
+end
 {% endcapture %}
 {% include code.html language="ruby" header="Handling exceptions" code=ruby %}
     </div>
@@ -366,12 +369,19 @@ curl
 {% endcapture %}
 {% include code.html language="bash" header="GET snippets/:id/render" code=bash %}
 
+{% capture javascript %}
+var { Jahuty, Snippet }  = require('@jahuty/jahuty');
+
+Jahuty.setKey('YOUR_API_KEY');
+
+Snippet.render(YOUR_SNIPPET_ID).then(render => console.log(render.content));
+{% endcapture %}
+{% include code.html language="javascript" header="GET snippets/:id/render" code=javascript %}
+
 {% capture php %}
-use Jahuty\Jahuty\{Jahuty, Snippet};
+$jahuty = new \Jahuty\Client('{{ key }}');
 
-Jahuty::setKey('{{ key }}');
-
-echo Snippet::render(1, [
+echo $jahuty->snippets->render(1, [
   "params" => [
     "foo" => "bar"
   ]
@@ -388,12 +398,35 @@ puts Jahuty::Snippet.render 1, params: { "foo": "bar" }
 {% endcapture %}
 {% include code.html language="ruby" header="GET snippets/:id/render" code=ruby %}
 
+{% capture html %}
+<!doctype html>
+<html>
+  <head>
+    <script src="https://unpkg.com/@jahuty/jahuty"></script>
+    <script>
+      window.addEventListener('load', function () {
+        jahuty.Jahuty.setKey('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
+        jahuty.Jahuty.initialize();
+      });
+    </script>
+  </head>
+  <body>
+    <div data-snippet-id="1">
+      <p>
+        Hello, world!
+      </p>
+    </div>
+  </body>
+</html>
+{% endcapture %}
+{% include code.html language="html" header="GET snippets/:id/render" code=html %}
+
 {% capture response %}
 {
   "content": "This is my first snippet!"
 }
 {% endcapture %}
-{% include code.html language="json" header="Response" code=response %}
+{% include code.html language="json" header="Response" code=response select=false toggle=false %}
     </div>
   </div>
 </section>

--- a/getting-started.md
+++ b/getting-started.md
@@ -3,12 +3,13 @@ title       : Getting started
 description : Getting started with Jahuty.
 keywords    : [getting, started]
 category    : getting-started
+permalink   : /:basename
 javascripts :
   - src: /assets/js/toggle.js
 ---
 {% include heading.html title="Getting started" lead="Welcome to Jahuty! We're excited to partner with you and help your team save tons of time. We know how difficult managing content in an application can be." %}
 
-Here's what you need to do:
+Here's what you need to do to get started:
 
 1. [Create your account](#create-your-account).
 1. [Open your first snippet](#open-your-first-snippet).
@@ -17,7 +18,7 @@ Here's what you need to do:
 
 ## Create your account
 
-Use the [registration form]({{ site.data.urls.app.sign_up }}) to create your Jahuty _account_. An account allows personalized access to our application. Be sure to use a strong password: your account is you, and your account is your password. Also, don't worry about your personal data: we make money by providing a great service, not selling data.
+[Sign up]({{ site.data.urls.app.sign_up }}) and create your Jahuty _account_. Remember to use a strong password. Your account is you, and your account is your password. Don't worry about your data. We make money by providing a great service, not selling your data.
 
 When you create your account, we'll create an _organization_ for you. An organization is a place where one or more people work together in Jahuty. Nearly everything in Jahuty is associated with an organization, including your account.
 
@@ -31,25 +32,33 @@ Snippets are more than just text. You can use the [Liquid templating language](/
 
 ## Install your first SDK
 
-A [Software Development Kit (SDK)]({% link sdks/overview.md %}) is an open source package we maintain to make interacting with [our API](/api) easier. SDKs provide objects and methods that abstract away our API's lower-level request/response details. SDKs are available in a number of languages, and you can choose the one that fits your stack.
+Installing a [Software Development Kit (SDK)]({% link sdks/overview.md %}) lets you output your snippet in your application. An SDK provides objects and methods that abstract away the details of [our API](/api). SDKs are available in a number of languages, and you can choose the one that fits your stack.
 
 <div class="card mb-4">
   <div class="card-header">
     <nav class="nav nav-pills nav-fill">
       <a class="nav-link active" data-toggle-type="activity" data-toggle-language="bash">cURL</a>
+      <a class="nav-link" data-toggle-type="activity" data-toggle-language="javascript">Node</a>
       <a class="nav-link" data-toggle-type="activity" data-toggle-language="php">PHP</a>
       <a class="nav-link" data-toggle-type="activity" data-toggle-language="ruby">Ruby</a>
+      <a class="nav-link" data-toggle-type="activity" data-toggle-language="html">Web</a>
     </nav>
   </div>
   <div class="card-body text-muted">
     <p class="m-0" data-toggle-type="visibility" data-toggle-language="bash">
       By default, our examples use <code>curl</code> and test sample data to interact with our API over HTTPS. Select one of our official SDKs to see examples in code.
     </p>
+    <p class="m-0" data-toggle-type="visibility" data-toggle-language="javascript">
+      <code>$ npm install jahuty --save</code> <a href="https://github.com/jahuty/jahuty-node" target="_blank"><i class="fab fa-github ml-2"></i></a>
+    </p>
     <p class="m-0" data-toggle-type="visibility" data-toggle-language="php">
       <code>$ composer require jahuty/jahuty-php</code> <a href="https://github.com/jahuty/jahuty-php" target="_blank"><i class="fab fa-github ml-2"></i></a>
     </p>
     <p class="m-0" data-toggle-type="visibility" data-toggle-language="ruby">
       <code>$ gem install jahuty</code> <a href="https://github.com/jahuty/jahuty-ruby" target="_blank"><i class="fab fa-github ml-2"></i></a>
+    </p>
+    <p class="m-0" data-toggle-type="visibility" data-toggle-language="html">
+      <code>&lt;script src="https://unpkg.com/@jahuty/jahuty"&gt;&lt;/script&gt;</code> <a href="https://github.com/jahuty/jahuty-node" target="_blank"><i class="fab fa-github ml-2"></i></a>
     </p>
   </div>
 </div>
@@ -61,10 +70,10 @@ A [Software Development Kit (SDK)]({% link sdks/overview.md %}) is an open sourc
 
 To render your first snippet, you'll need two values:
 
-1. Your snippet's _id_. This is the number beside your snippet's name in the editor.
-1. Your organization's _API key_. There's a temporary one in your welcome email.
+1. Your snippet's _id_ (the number beside your snippet's name in the editor).
+1. Your organization's _API key_ (there's a temporary one in your welcome email).
 
-(In the examples below, we've used a sample test id and API key to provide a working example. To render your first snippet, however, you should replace the sample API key and snippet id with your actual values.)
+(In the examples below, we've used a sample test id and API key to provide a working example. To render your first snippet, you should replace the sample API key and snippet id with your actual values.)
 
 {% capture bash %}
 curl https://api.jahuty.com/snippets/{{ example_id }}/render \
@@ -73,11 +82,9 @@ curl https://api.jahuty.com/snippets/{{ example_id }}/render \
 {% endcapture %}
 
 {% capture php %}
-use Jahuty\Jahuty\{Jahuty, Snippet};
+$jahuty = new \Jahuty\Client('{{ example_api_key }}');
 
-Jahuty::setKey('{{ example_api_key }}');
-
-echo Snippet::render({{ example_id }});
+echo $jahuty->snippets->render({{ example_id }});
 {% endcapture %}
 
 {% capture ruby %}
@@ -88,17 +95,52 @@ Jahuty.key = "{{ example_api_key }}"
 puts Jahuty::Snippet.render {{ example_id }}
 {% endcapture %}
 
+{% capture javascript %}
+var { Jahuty, Snippet }  = require('@jahuty/jahuty');
+
+Jahuty.setKey('YOUR_API_KEY');
+
+Snippet.render(YOUR_SNIPPET_ID).then(render => console.log(render.content));
+{% endcapture %}
+
+{% capture html %}
+<!doctype html>
+<html>
+  <head>
+    <script src="https://unpkg.com/@jahuty/jahuty"></script>
+    <script>
+      window.addEventListener('load', function () {
+        jahuty.Jahuty.setKey('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
+        jahuty.Jahuty.initialize();
+      });
+    </script>
+  </head>
+  <body>
+    <div data-snippet-id="1">
+      <p>
+        Hello, world!
+      </p>
+    </div>
+  </body>
+</html>
+{% endcapture %}
+
 <div class="card mb-4">
   <div class="card-header">
     <nav class="nav nav-pills nav-fill">
       <a class="nav-link active" data-toggle-type="activity" data-toggle-language="bash">cURL</a>
+      <a class="nav-link" data-toggle-type="activity" data-toggle-language="javascript">Node</a>
       <a class="nav-link" data-toggle-type="activity" data-toggle-language="php">PHP</a>
       <a class="nav-link" data-toggle-type="activity" data-toggle-language="ruby">Ruby</a>
+      <a class="nav-link" data-toggle-type="activity" data-toggle-language="html">Web</a>
     </nav>
   </div>
   <div class="card-body text-muted">
     <div data-toggle-type="visibility" data-toggle-language="bash">
       {% highlight bash %}{{ bash }}{% endhighlight %}
+    </div>
+    <div data-toggle-type="visibility" data-toggle-language="javascript">
+      {% highlight javascript %}{{ javascript }}{% endhighlight %}
     </div>
     <div data-toggle-type="visibility" data-toggle-language="php">
       {% highlight php %}{{ php }}{% endhighlight %}
@@ -106,9 +148,12 @@ puts Jahuty::Snippet.render {{ example_id }}
     <div data-toggle-type="visibility" data-toggle-language="ruby">
       {% highlight ruby %}{{ ruby }}{% endhighlight %}
     </div>
+    <div data-toggle-type="visibility" data-toggle-language="html">
+      {% highlight html %}{{ html }}{% endhighlight %}
+    </div>
   </div>
 </div>
 
 ## That's it!
 
-We hope you've enjoyed getting started with Jahuty! If you have any questions, [let us know]({{ site.data.urls.contact }}). Otherwise, feel free to learn more about Jahuty's [components]({% link components/overview.md %}), [using templates]({% link liquid/introduction.md %}), [choosing an SDK]({% link sdks/overview.md %}), or [using our API]({% link api.html %}).
+We hope you've enjoyed getting started with Jahuty! If you have any questions, [let us know]({{ site.data.urls.contact }}). Otherwise, feel free to learn more about Jahuty's [components]({% link components/overview.md %}), [templates]({% link liquid/introduction.md %}), [SDKs]({% link sdks/overview.md %}), or [API]({% link api.html %}).


### PR DESCRIPTION
1. Update the PHP examples for the new instance-based syntax; 
2. Add examples for node and "web" to the "getting started" and "api" articles.
3. Simplify the "getting started" nav. 