### PR TITLE
Fix amplify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.6.6-node-browsers
+      - image: circleci/ruby:2.7.2-node-browsers
     environment:
       BUNDLE_PATH: ~/repo/vendor/bundle
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+.DS_Store
 _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+.ruby-version
 spec/examples.txt
 test_results
 vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
+
+ruby "2.7.2"
+
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,5 +165,8 @@ DEPENDENCIES
   wdm (~> 0.1.1)
   webdrivers
 
+RUBY VERSION
+   ruby 2.7.2p137
+
 BUNDLED WITH
    2.1.4

--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,13 @@ defaults:
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
-exclude: [README.md, spec, amplify.yml, LICENSE]
+exclude: [
+  .circleci,
+  README.md,
+  spec,
+  amplify.yml,
+  LICENSE
+]
 
 algolia:
   application_id: FBGAMPVM3R


### PR DESCRIPTION
Looks like the build of #42 in AWS Amplify failed with:

```
2021-04-11T15:51:49.802Z [WARNING]: nokogiri-1.11.3-x86_64-linux requires ruby version >= 2.5, < 3.1.dev, which is
                                    incompatible with the current version, ruby 2.4.6p354
2021-04-11T15:51:49.844Z [ERROR]: !!! Build failed
2021-04-11T15:51:49.844Z [ERROR]: !!! Non-Zero Exit Code detected
2021-04-11T15:51:49.845Z [INFO]: # Starting environment caching...
2021-04-11T15:51:49.845Z [INFO]: # Environment caching completed
Terminating logging...
```

Let's see if specifying the ruby version in the `Gemfile` will help.