### PR TITLE
Add rvm command to install and use 2.7.2

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,6 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
+        - rvm install 2.7.2 && rvm use 2.7.2
         - gem install bundler
         - bundle install --deployment --without development test
     build:


### PR DESCRIPTION
#43 did not fix the issue. Based on this [Dockerfile](https://github.com/aws-amplify/amplify-console/blob/master/images/amazonlinux1/Dockerfile), it looks like AWS uses `rvm`. So, let's try using `rvm` to install and use 2.7.2.